### PR TITLE
Improve chat to doc script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Documentos-automaticos
+
+Este repositorio contiene ejemplos simples para automatizar la creación de documentos.
+
+## Script de ejemplo
+
+- **guardar_chat.py**: carga una plantilla de Word, procesa un texto de chat separando los mensajes de "Usuario:" y "ChatGPT:" e inserta el nombre del hablante en negrita antes de cada mensaje. Finalmente guarda el documento.
+
+Para ejecutar el script asegúrate de tener instalada la librería `python-docx` y de contar con una plantilla llamada `plantilla_base.docx` en el mismo directorio.
+
+El texto de la conversación debe almacenarse en una variable llamada `texto_chat`, tal como se muestra en el ejemplo incluido en el script.
+
+```bash
+python3 guardar_chat.py
+```

--- a/guardar_chat.py
+++ b/guardar_chat.py
@@ -1,0 +1,62 @@
+"""Script para guardar una conversación en un documento Word."""
+
+import os
+from docx import Document
+
+def guardar_chat_en_docx(texto_chat: str,
+                          plantilla: str = "plantilla_base.docx",
+                          salida: str = "chat_guardado.docx") -> None:
+    """Carga la plantilla, procesa el chat y guarda el documento.
+
+    Parameters
+    ----------
+    texto_chat : str
+        Texto de la conversación a agregar.
+    plantilla : str, optional
+        Nombre de la plantilla a cargar. Por defecto ``plantilla_base.docx``.
+    salida : str, optional
+        Nombre del documento resultante. Por defecto ``chat_guardado.docx``.
+    """
+    if not os.path.exists(plantilla):
+        raise FileNotFoundError(f"No se encontró la plantilla: {plantilla}")
+
+    # Cargar documento base
+    doc = Document(plantilla)
+
+    # Procesar cada línea de la conversación
+    for linea in texto_chat.splitlines():
+        linea = linea.strip()
+        if not linea:
+            continue
+
+        if linea.startswith("Usuario:"):
+            hablante = "Usuario"
+            mensaje = linea[len("Usuario:"):].strip()
+        elif linea.startswith("ChatGPT:"):
+            hablante = "ChatGPT"
+            mensaje = linea[len("ChatGPT:"):].strip()
+        else:
+            # Ignorar líneas que no estén etiquetadas correctamente
+            continue
+
+        # Nombre del hablante en negrita
+        p_nombre = doc.add_paragraph()
+        run = p_nombre.add_run(f"{hablante}:")
+        run.bold = True
+
+        # Mensaje del hablante en un párrafo independiente
+        doc.add_paragraph(mensaje)
+
+    # Guardar el documento resultante
+    doc.save(salida)
+
+
+if __name__ == "__main__":
+    # Texto de ejemplo simulando una conversación
+    texto_chat = (
+        "Usuario: Hola, ¿cómo estás?\n"
+        "ChatGPT: ¡Hola! Estoy aquí para ayudarte.\n"
+        "Usuario: Gracias por la información."
+    )
+
+    guardar_chat_en_docx(texto_chat)


### PR DESCRIPTION
## Summary
- enhance `guardar_chat.py` to parse each chat line and format speaker names in bold
- expand README with updated script description and usage tips

## Testing
- `python3 -m py_compile guardar_chat.py`
- `python3 guardar_chat.py` *(fails: FileNotFoundError: No se encontró la plantilla: plantilla_base.docx)*

------
https://chatgpt.com/codex/tasks/task_b_683f64e08e8c832e80c929b93c5af928